### PR TITLE
remove extraneous '}' from shellHook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@
             export DEVKITARM="$DEVKITPRO/devkitARM"
             export DEVKITPPC="$DEVKITPRO/devkitPPC"
             export CPATH=${CPATH}
-            export PATH="${pkgs.lib.makeBinPath ["$DEVKITPRO" "$DEVKITARM" "$DEVKITPPC"]}:$PATH}"
+            export PATH="${pkgs.lib.makeBinPath ["$DEVKITPRO" "$DEVKITARM" "$DEVKITPPC"]}:$PATH"
           '';
         };
       });


### PR DESCRIPTION
Haven't updated my flake in a while and I was looking to upgrade to the new devkit version, however my environment was getting nuked every time I entered the usual devshell.

My nix experience is still nascent, but I think this extra bracket was the problem and it seems to fix the issue